### PR TITLE
Setting value can be false

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -41,7 +41,7 @@ class ConfigReader {
         const customConfig = vscode.workspace.getConfiguration('xml2json.options')
         options.forEach(key => {
             const val = customConfig.get(key)
-            if (val) {
+            if (typeof val !== 'undefined') {
                 config[key] = val
             }
         })


### PR DESCRIPTION
Setting value can be false, so we must check for not undefined instead of doing a truthy check